### PR TITLE
replace , .

### DIFF
--- a/MeltingApp/MeltingApp/ViewModels/EventViewModel.cs
+++ b/MeltingApp/MeltingApp/ViewModels/EventViewModel.cs
@@ -436,6 +436,8 @@ namespace MeltingApp.ViewModels
 
         private async void HandleOpenMapEventCommand()
         {
+            Event.latitude = Event.latitude.Replace(".", ",");
+            Event.longitude = Event.longitude.Replace(".", ",");
             var success = await CrossExternalMaps.Current.NavigateTo("Location", Double.Parse(Event.latitude), Double.Parse(Event.longitude));
             if (!success)
             {


### PR DESCRIPTION
Obrir amb Maps solucionat, el problema era que al crear es guarda amb "." i per fer la crida al maps ha d'estar amb ",". Amb un replace abans de cridar a obrir maps ja funciona perfectament :D