### PR TITLE
Eliminar event

### DIFF
--- a/MeltingApp/MeltingApp/Resources/ApiRoutes.cs
+++ b/MeltingApp/MeltingApp/Resources/ApiRoutes.cs
@@ -16,6 +16,7 @@ namespace MeltingApp.Resources
             public const string RegisterUser = "Register";
             public const string LoginUser = "Login";
             public const string CreateEvent = "CreateEvent";
+            public const string DeleteEvent = "DeleteEvent";
             public const string GetProfileUser = "GetProfile";
             public const string EditProfileUser = "EditProfile";
             public const string AvatarProfileUser = "AvatarProfile";

--- a/MeltingApp/MeltingApp/Services/ApiClientService.cs
+++ b/MeltingApp/MeltingApp/Services/ApiClientService.cs
@@ -69,6 +69,7 @@ namespace MeltingApp.Services
         {
             { new Tuple<Type, string>(typeof(Event), ApiRoutes.Methods.UnconfirmAssistance), $"{ApiRoutes.Prefix.Event_id}{ApiRoutes.Endpoints.UnconfirmAssistance}"  },
             { new Tuple<Type, string>(typeof(User), ApiRoutes.Methods.DeleteAccount), $"{ApiRoutes.Prefix.Users}" },
+            { new Tuple<Type, string>(typeof(Event), ApiRoutes.Methods.DeleteEvent), $"{ApiRoutes.Prefix.Event_id}" },
             { new Tuple<Type, string>(typeof(Comment), ApiRoutes.Methods.DeleteComment), $"{ApiRoutes.Prefix.Comment_id}"}
         };
              

--- a/MeltingApp/MeltingApp/ViewModels/EventViewModel.cs
+++ b/MeltingApp/MeltingApp/ViewModels/EventViewModel.cs
@@ -50,6 +50,8 @@ namespace MeltingApp.ViewModels
         public Command OpenMapEventCommand { get; set; }
         public Command InfoCommentCommand { get; set; }
         public Command NavigateToMyEventListPageCommand { get; set; }
+	    public Command DeleteEventCommand{ get; set; }
+
 
 
         public Event Event
@@ -212,6 +214,7 @@ namespace MeltingApp.ViewModels
             _dataBaseService = DependencyService.Get<IDataBaseService>();
 
             CreateEventCommand = new Command(HandleCreateEventCommand);
+            DeleteEventCommand = new Command(HandleDeleteEventCommand);
             ModifyEventCommand = new Command(HandleModifyEventCommand);
             NavigateToModifyEventCommand = new Command(HandleNavigateToModifyEventCommand);
             ConfirmAssistanceCommand = new Command(HandleConfirmAssistanceCommand);
@@ -476,6 +479,28 @@ namespace MeltingApp.ViewModels
                 
             }
             var events_after = _dataBaseService.GetCollectionWithChildren<Event>(e => true);
+        }
+
+	    async void HandleDeleteEventCommand()
+	    {
+	        var meltingUriParser = new MeltingUriParser();
+	        meltingUriParser.AddParseRule(ApiRoutes.UriParameters.EventId, $"{eventidaux}");
+
+	        await _apiClientService.DeleteAsync<Event, Event>(ApiRoutes.Methods.DeleteEvent,
+	            (isSuccess, responseMessage) =>
+	            {
+	                if (isSuccess)
+	                {
+	                    DependencyService.Get<IOperatingSystemMethods>().ShowToast("Event deleted successfully");
+	                    
+	                    _navigationService.PopAsync();
+                        GetAllEvents();
+	                }
+	                else
+	                {
+	                    DependencyService.Get<IOperatingSystemMethods>().ShowToast(responseMessage);
+	                }
+	            }, meltingUriParser);
         }
 
         private async void HandleOpenMapEventCommand()

--- a/MeltingApp/MeltingApp/Views/Pages/ViewEvent.xaml
+++ b/MeltingApp/MeltingApp/Views/Pages/ViewEvent.xaml
@@ -14,6 +14,7 @@
             <Label Text="{Binding Event.date}"></Label>
             <Button Text="I'll asssit" Command="{Binding ConfirmAssistanceCommand}"></Button>
             <Button Text="Modify Event" Command="{Binding NavigateToModifyEventCommand}" IsVisible="{Binding UserOwnsEvent}"></Button>
+            <Button Text="Delete Event" Command="{Binding DeleteEventCommand}" IsVisible="{Binding UserOwnsEvent}"></Button>
             <Button Text="View in Maps" Command="{Binding OpenMapEventCommand}"></Button>
             <Entry Text="{Binding Comment.content}"></Entry>
             <Button Text="Create comment" Command="{Binding CreateCommentCommand}"></Button>


### PR DESCRIPTION
Acabar eliminar event. Funciona correctament però quan elimina un event hi ha un temps entre que s'elimina i es torna a mostrar la llista d'elements. La millor manera que he trobat per disimular-ho es com està ara però accepto propostes.

Igual que modificar element només es mostra el botó si és el teu event.

No se ben bé que passa amb els comentaris de l'event eliminat, suposo que backend se'n encarrega.